### PR TITLE
[Editorial] Update spelling

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -11,11 +11,11 @@
 				<h2 epub:type="ordinal z3998:roman">I</h2>
 				<p epub:type="title">Thery’s Trade</p>
 			</hgroup>
-			<p>Four men sat about a table on the sidewalk in front of the Café of the Nations in the High Street of Cadiz and talked business.</p>
+			<p>Four men sat about a table on the sidewalk in front of the Café of the Nations in the High Street of Cádiz and talked business.</p>
 			<p>Leon Gonsalez was one, Poiccart was another, George Manfred was a notable third, and one Thery, or Saimont, was the fourth. Of this quartet, only Thery requires no introduction to the student of contemporary history. In the Bureau of Public Affairs you will find his record. As Thery, alias Saimont, he is registered and to all students of Criminology and Physiognomy, he must need no introduction.</p>
 			<p>He sat at the little table, this man, obviously ill at ease, pinching his fat cheeks, smoothing his shaggy eyebrows, fingering the white scar on his unshaven chin, doing all the things that the lower classes do when they suddenly find themselves placed on terms of equality with their betters.</p>
 			<p>For although Gonsalez, with the light blue eyes and the restless hands, and Poiccart, heavy, saturnine, and suspicious, and George Manfred, with his grey shot beard and single eyeglass, were less famous in the criminal world, each was a great man, as you shall learn.</p>
-			<p>Manfred laid down the <i epub:type="se:name.publication.newspaper" xml:lang="es">Heraldo di Madrid</i>, removed his eyeglass, rubbed it with a spotless handkerchief, and laughed quietly.</p>
+			<p>Manfred laid down the <i epub:type="se:name.publication.newspaper" xml:lang="es">Heraldo de Madrid</i>, removed his eyeglass, rubbed it with a spotless handkerchief, and laughed quietly.</p>
 			<p>“These Russians are droll,” he commented.</p>
 			<p>Poiccart frowned and reached for the newspaper. “Who is it⁠—this time?”</p>
 			<p>“A Governor of one of the Southern Provinces.”</p>


### PR DESCRIPTION
Some minor corrections related to the Spanish words in this chapter. Namely:
- Cádiz (the city in the very south of Spain) has an accent in the "a", even in English. 
- "Heraldo de Madrid" is written as "de Madrid" (meaning "from Madrid") in Spanish. Using "di Madrid" would probably be correct in Italian, but not in Spanish. The "Heraldo de Madrid" was a famous newspaper (https://hemerotecadigital.bne.es/hd/en/card?sid=383636).